### PR TITLE
Fix/css leaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alma/widgets",
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8981,6 +8981,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.ismatch": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jest": "^26.6.0",
     "jest-config": "^26.6.0",
     "lint-staged": "^10.5.3",
+    "lodash.get": "^4.4.2",
     "microbundle": "github:olance/microbundle#rollup/config-override",
     "postcss-assets": "^5.0.0",
     "prettier": "^2.2.1",

--- a/remToPx.js
+++ b/remToPx.js
@@ -1,0 +1,79 @@
+const getAtPath = require('lodash.get')
+
+// https://stackoverflow.com/a/1175468/283481
+function isObjectLiteral(obj) {
+  if (typeof obj !== 'object' || obj === null)
+    return false
+
+  // get obj's Object constructor's prototype
+  let ObjProto = obj
+  while (Object.getPrototypeOf(ObjProto = Object.getPrototypeOf(ObjProto)) !== null) {
+  }
+
+  return Object.getPrototypeOf(obj) === ObjProto
+}
+
+class RemToPxConverter {
+  constructor(twTheme, pxBase) {
+    this._twTheme = twTheme
+    this._pxBase = pxBase
+  }
+
+  _convertValue(value, preserveUnknowns = false, propPath = null) {
+    if (isObjectLiteral(value)) {
+      return this.convert(value, propPath)
+    } else if (Array.isArray(value)) {
+      return value.map((v) => this._convertValue(v, true))
+    } else if (typeof value === 'string') {
+      return value.replace(
+        /(?<=^|\s|[()])([+-]?(?:(?:\.\d+)|(?:\d+(?:\.\d+)?))(?:[eE][+-]?\d+)?)rem(?=\)|\s|$)/g,
+        (match, remValue) => `${parseFloat(remValue) * this._pxBase}px`,
+      )
+    } else if (typeof value === 'function' && propPath) {
+      return (theme, utils) => ({
+        ...this.convert(getAtPath(this._twTheme, propPath)(theme, utils), propPath),
+      })
+    } else if (preserveUnknowns) {
+      return value
+    }
+
+    return null
+  }
+
+  convert(obj = this._twTheme, path = '') {
+    const target = {}
+
+    for (const propName in obj) {
+      if (!Object.prototype.hasOwnProperty.call(obj, propName)) {
+        continue
+      }
+
+      const currentPath = path === '' ? propName : `${path}.${propName}`
+      const value = obj[propName]
+
+      if (isObjectLiteral(value)) {
+        target[propName] = this.convert(value, currentPath)
+      } else {
+        const converted = this._convertValue(value, false, currentPath)
+        if (converted != null) {
+          target[propName] = converted
+        }
+      }
+    }
+
+    return target
+  }
+}
+
+function remToPx(twTheme, pxBase) {
+  const converter = new RemToPxConverter(twTheme, pxBase)
+  return converter.convert()
+}
+
+module.exports = (twTheme, pxBase = 16) => ({
+  config: {
+    theme: {
+      ...remToPx(twTheme, pxBase),
+    },
+  },
+})

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -24,6 +24,17 @@
     * {
       -webkit-font-smoothing: antialiased !important;
       -moz-osx-font-smoothing: grayscale !important;
+      -webkit-text-size-adjust: 100% !important;
+      line-height: normal !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      letter-spacing: normal;
+    }
+
+    button:focus, button:hover, input[type="button"]:focus, input[type="button"]:hover,
+    input[type="reset"]:focus, input[type="reset"]:hover, input[type="submit"]:focus,
+    input[type="submit"]:hover {
+      text-decoration: none;
     }
   }
 }

--- a/src/widgets/HowItWorks/HowItWorksRenderer.tsx
+++ b/src/widgets/HowItWorks/HowItWorksRenderer.tsx
@@ -78,7 +78,7 @@ export function HowItWorksRenderer({
 
   return (
     <Modal closeCallback={closeCallback}>
-      <div className="atw-overflow-auto atw-relative atw-flex atw-flex-row atw-flex-wrap atw-rounded-sm atw-shadow-lg atw-w-screen atw-h-screen md:atw-h-650 lg:atw-w-9/12 md:atw-max-w-3xl atw-max-h-screen atw-bg-white">
+      <div className="atw-overflow-auto atw-relative atw-flex atw-flex-row atw-flex-wrap atw-rounded-sm atw-shadow-lg atw-w-screen atw-h-screen md:atw-h-650 lg:atw-w-9/12 md:atw-max-w-3xl atw-max-h-screen atw-bg-white atw-text-base">
         <button
           onClick={closeCallback}
           className="atw-text-3xl atw-opacity-50 hover:atw-opacity-100 focus:atw-opacity-100 atw-absolute atw-top-3 atw-right-4 atw-outline-none atw-transform hover:atw-scale-125 focus:atw-scale-125 atw-transition-transform atw-duration-100"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,7 @@ module.exports = {
   theme: {
     extend: {
       spacing: {
-        7: '1.75rem',
+        7: '28px',
       },
       opacity: {
         15: '0.15',
@@ -49,18 +49,20 @@ module.exports = {
         'above-xl': '0 -20px 25px -5px rgba(0, 0, 0, 0.1), 0 -10px 10px -5px rgba(0, 0, 0, 0.04)',
       },
       fontSize: {
-        '5xl': '2.75rem',
+        '5xl': '44px',
       },
       inset: {
-        3: '0.75rem',
-        4: '1rem',
+        3: '12px',
+        4: '16px',
       },
     },
   },
   variants: {
     backgroundColor: [...defaultConfig.variants.backgroundColor, 'group-hover'],
   },
-  plugins: [],
+  plugins: [
+    require('./remToPx')(defaultConfig.theme, 16),
+  ],
   corePlugins: {
     // Deactivate preflight's inclusion, it will be added "manually" so that it's scoped to Alma
     preflight: false,


### PR DESCRIPTION
`rem` units make us dependent on the widgets' hosting page and its own definition of font size on the `html` element.
It makes the widgets design very brittle, so we need to switch to pixels to have better control over our widgets design.

This PR adds a Tailwind plugin that will recursively convert any `rem` dimension to its `px` equivalent (with a base of `1rem = 16px`), and also adds a few styles reset based on what WordPress/WooCommerce default theme breaks.

Will probably need to update again as I implement the lib on other platforms...